### PR TITLE
The htop packages have moved to EPEL repository.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ version          "2.0.0"
 
 recipe "htop", "Installs htop monitoring"
 
-depends "yum-repoforge"
+depends "yum-epel"
 
 supports "debian"
 supports "ubuntu"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,7 +3,7 @@
 # Recipe:: default
 #
 
-include_recipe "yum-repoforge" if platform_family?("rhel")
+include_recipe "yum-epel" if platform_family?("rhel")
 
 package "htop" do
   version node["htop"]["version"]


### PR DESCRIPTION
See:
https://wiki.centos.org/AdditionalResources/Repositories/RPMForge

RPMForge/RepoForge is a dead project. It is not maintained.
DO NOT USE.